### PR TITLE
Fix issue when running `(explore parallel-step (query ...))`

### DIFF
--- a/tools.rkt
+++ b/tools.rkt
@@ -160,7 +160,7 @@
                                                      (pause st g2))))
       ((conj g1 g2)     (parallel-step-simple (bind (pause st g1) g2)))
       ((relate thunk _) (pause st (thunk)))
-      ((== t1 t2)       (unify t1 t2 st))))
+      ((== t1 t2)       (state->stream (unify t1 t2 st)))))
   (define (parallel-expand g)
     (let loop ((g g))
       (match g


### PR DESCRIPTION
```racket
;;;; This works as expected.
;; (explore step (query (a b) (appendo a b '(1 2 3 4))))

;;;; This fails with:
(explore parallel-step (query (a b) (appendo a b '(1 2 3 4))))
;; ————— run examples.rkt —————
;; Using step procedure: parallel-step
;; Exploring query:
;; (query (a b) (appendo a b (quote (1 2 3 4))))

;; ================================================================================
;; Current Depth: 0
;; Number of Choices: 1

;; | Choice 1:
;; |  a = #s(var a 1)
;; |  b = #s(var b 2)
;; |  Constraints:
;; |  * (appendo #s(var a 1) #s(var b 2) (1 2 3 4))

;; [h]elp, [u]ndo, or choice number>
;; 1

;; ================================================================================
;; Previous Choice:
;; |  a = #s(var a 1)
;; |  b = #s(var b 2)
;; |  Constraints:
;; |  * (appendo #s(var a 1) #s(var b 2) (1 2 3 4))

;; Current Depth: 1
;; Number of Choices: 2

;; | Choice 1:
;; match: no matching clause for #s(bind #s(state ((#s(var #f 0) #s(var a 1) #s(var b 2))) () () ()) #s(conj #s(== () #s(var a 1)) #s(== #s(var b 2) (1 2 3 4))))
```

I traced it down to:

`prune/goal` returns a `pause`: https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/tools.rkt#L83

`parallel-step` then [calls](https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/tools.rkt#L191) `parallel-start` which then just [returns the state](https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/tools.rkt#L170).

That doesn't happen with the regular `step` because [regular `step`](https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/microk-fo.rkt#L54) returns `(state->stream ...)`.

Wrapping the `==` match in `parallel-step-start` with a `state->stream` call seems to be the solution.